### PR TITLE
feat: enable asyncAggregateWithRandomness unit tests

### DIFF
--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -6,7 +6,7 @@ import { finished } from "stream/promises";
 import type { ReadableStream } from "stream/web";
 import { PREBUILD_DIR, getBinaryName, getPrebuiltBinaryPath } from "../utils";
 
-const VERSION = "0.1.0-rc.6";
+const VERSION = "0.1.0-rc.5";
 
 // CLI runner and entrance for this file when called by npm/yarn
 install().then(

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -6,7 +6,7 @@ import { finished } from "stream/promises";
 import type { ReadableStream } from "stream/web";
 import { PREBUILD_DIR, getBinaryName, getPrebuiltBinaryPath } from "../utils";
 
-const VERSION = "0.1.0-rc.4";
+const VERSION = "0.1.0-rc.5";
 
 // CLI runner and entrance for this file when called by npm/yarn
 install().then(

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -6,7 +6,7 @@ import { finished } from "stream/promises";
 import type { ReadableStream } from "stream/web";
 import { PREBUILD_DIR, getBinaryName, getPrebuiltBinaryPath } from "../utils";
 
-const VERSION = "0.1.0-rc.5";
+const VERSION = "0.1.0-rc.6";
 
 // CLI runner and entrance for this file when called by npm/yarn
 install().then(

--- a/src/aggregateWithRandomness.ts
+++ b/src/aggregateWithRandomness.ts
@@ -100,7 +100,7 @@ export function asyncAggregateWithRandomness(sets: Array<PkAndSerializedSig>): P
 			{
 				args: ["u32"],
 				returns: "void",
-        threadsafe: true,
+				threadsafe: true,
 			}
 		);
 

--- a/src/aggregateWithRandomness.ts
+++ b/src/aggregateWithRandomness.ts
@@ -100,6 +100,7 @@ export function asyncAggregateWithRandomness(sets: Array<PkAndSerializedSig>): P
 			{
 				args: ["u32"],
 				returns: "void",
+        threadsafe: true,
 			}
 		);
 

--- a/test/unit/aggregateWithRandomness.test.ts
+++ b/test/unit/aggregateWithRandomness.test.ts
@@ -115,7 +115,7 @@ describe("Aggregate With Randomness", () => {
 	});
 
 	// this api only works on MacOS not Linux
-	describe.skip("asyncAggregateWithRandomness()", () => {
+	describe("asyncAggregateWithRandomness()", () => {
 		it("should not accept an empty array argument", async () => {
 			try {
 				await asyncAggregateWithRandomness([]);


### PR DESCRIPTION
**Description**
- fix `asyncAggregateWithRandomness()` api on Linux

Closes #4 